### PR TITLE
adding logic for resources in fw

### DIFF
--- a/samples/in_bp.consul.json
+++ b/samples/in_bp.consul.json
@@ -22,6 +22,10 @@
 						"type": "contains"
 					},
 					{
+						"id": "service.db.db1",
+						"type": "contains"
+					},
+					{
 						"id": "service.web.web1",
 						"type": "contains"
 					},
@@ -56,6 +60,10 @@
 					},
 					{
 						"id": "service.noty.not2",
+						"type": "contains"
+					},
+					{
+						"id": "service.db.db2",
 						"type": "contains"
 					},
 					{
@@ -145,15 +153,15 @@
 			"cluster-dc1": {
 				"Associations": [
 					{
+						"id": "resource.consul-server.dc1-server3",
+						"type": "contains"
+					},
+					{
 						"id": "resource.consul-server.dc1-server1",
 						"type": "contains"
 					},
 					{
 						"id": "resource.consul-server.dc1-server2",
-						"type": "contains"
-					},
-					{
-						"id": "resource.consul-server.dc1-server3",
 						"type": "contains"
 					}
 				],
@@ -206,19 +214,19 @@
 			"dc1-server3": {
 				"Associations": [
 					{
-						"id": "resource.consul-server.dc1-server2",
+						"id": "resource.consul-server.dc1-server1",
 						"type": "egress"
 					},
 					{
-						"id": "resource.consul-server.dc1-server2",
+						"id": "resource.consul-server.dc1-server1",
 						"type": "ingress"
 					},
 					{
-						"id": "resource.consul-server.dc1-server1",
+						"id": "resource.consul-server.dc1-server2",
 						"type": "egress"
 					},
 					{
-						"id": "resource.consul-server.dc1-server1",
+						"id": "resource.consul-server.dc1-server2",
 						"type": "ingress"
 					}
 				],


### PR DESCRIPTION
1. Why is this change necessary?
    Missing firewall items in the allocation

2. How does it address the issue?
   It assings into the first clients 

3. What side effects does this change have?
   NA

```
+++ b/samples/in_bp.consul.hcl
@@ -7,15 +7,19 @@ datacenter "dc1" {
 resource "consul-client" "dc1-client1" {
 
   association {
-    id   = "service.log.log1"
+    id   = "service.db.db1"
     type = "contains"
   }
   association {
-    id   = "service.noty.not1"
+    id   = "service.auth.auth1"
     type = "contains"
   }
   association {
-    id   = "service.auth.auth1"
+    id   = "service.log.log1"
+    type = "contains"
+  }
+  association {
+    id   = "service.noty.not1"
     type = "contains"
   }
   association {
@@ -44,15 +48,19 @@ resource "consul-client" "dc1-client1" {
 resource "consul-client" "dc1-client2" {
 
   association {
-    id   = "service.log.log2"
+    id   = "service.db.db2"
     type = "contains"
   }
   association {
-    id   = "service.noty.not2"
:

```

